### PR TITLE
feat: support bogus comments

### DIFF
--- a/packages/angular-html-parser/README.md
+++ b/packages/angular-html-parser/README.md
@@ -45,6 +45,7 @@ interface Options {
 - add `canSelfClose` option
 - allow case-insensitive closing tags for non-foreign elements
 - fix `Comment#sourceSpan`
+- support [bogus comments](https://www.w3.org/TR/html5/syntax.html#bogus-comment-state) (`<!...>`, `<?...>`)
 
 ## Development
 

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -321,6 +321,22 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn} from './ast_spe
         });
       });
 
+      describe('bogus comments', () => {
+        it('should preserve bogus comments', () => {
+          expect(humanizeDom(parser.parse('<!- comment --><div></div>', 'TestComp'))).toEqual([
+            [html.Comment, '- comment --', 0],
+            [html.Element, 'div', 0],
+          ]);
+        });
+
+        it('should preserve bogus comments', () => {
+          expect(humanizeDom(parser.parse('<?- comment --><div></div>', 'TestComp'))).toEqual([
+            [html.Comment, '?- comment --', 0],
+            [html.Element, 'div', 0],
+          ]);
+        });
+      });
+
       describe('expansion forms', () => {
         it('should parse out expansion forms', () => {
           const parsed = parser.parse(
@@ -594,9 +610,8 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn} from './ast_spe
 
         it('should also report lexer errors', () => {
           const errors = parser.parse('<!-err--><div></p></div>', 'TestComp').errors;
-          expect(errors.length).toEqual(2);
+          expect(errors.length).toEqual(1);
           expect(humanizeErrors(errors)).toEqual([
-            [TokenType.COMMENT_START, 'Unexpected character "e"', '0:3'],
             [
               'p',
               'Unexpected closing tag "p". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags',

--- a/packages/compiler/test/ml_parser/lexer_spec.ts
+++ b/packages/compiler/test/ml_parser/lexer_spec.ts
@@ -74,12 +74,6 @@ import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_u
         ]);
       });
 
-      it('should report <!- without -', () => {
-        expect(tokenizeAndHumanizeErrors('<!-a')).toEqual([
-          [lex.TokenType.COMMENT_START, 'Unexpected character "a"', '0:3']
-        ]);
-      });
-
       it('should report missing end comment', () => {
         expect(tokenizeAndHumanizeErrors('<!--')).toEqual([
           [lex.TokenType.RAW_TEXT, 'Unexpected character "EOF"', '0:4']
@@ -105,11 +99,31 @@ import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_u
       });
     });
 
+    describe('bogus comments', () => {
+      it('should parse bogus comments (<!...>)', () => {
+        expect(tokenizeAndHumanizeParts('<!-t\ne\rs\r\nt-->')).toEqual([
+          [lex.TokenType.COMMENT_START],
+          [lex.TokenType.RAW_TEXT, '-t\ne\ns\nt--'],
+          [lex.TokenType.COMMENT_END],
+          [lex.TokenType.EOF],
+        ]);
+      });
+
+      it('should parse bogus comments (<?...>)', () => {
+        expect(tokenizeAndHumanizeParts('<?--t\ne\rs\r\nt--?>')).toEqual([
+          [lex.TokenType.COMMENT_START],
+          [lex.TokenType.RAW_TEXT, '?--t\ne\ns\nt--?'],
+          [lex.TokenType.COMMENT_END],
+          [lex.TokenType.EOF],
+        ]);
+      });
+    });
+
     describe('doctype', () => {
       it('should parse doctypes', () => {
         expect(tokenizeAndHumanizeParts('<!doctype  html >')).toEqual([
           [lex.TokenType.DOC_TYPE_START],
-          [lex.TokenType.RAW_TEXT, 'html '],
+          [lex.TokenType.RAW_TEXT, '  html '],
           [lex.TokenType.DOC_TYPE_END],
           [lex.TokenType.EOF],
         ]);
@@ -118,15 +132,9 @@ import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_u
       it('should store the locations', () => {
         expect(tokenizeAndHumanizeSourceSpans('<!doctype  html >')).toEqual([
           [lex.TokenType.DOC_TYPE_START, '<!doctype'],
-          [lex.TokenType.RAW_TEXT, 'html '],
+          [lex.TokenType.RAW_TEXT, '  html '],
           [lex.TokenType.DOC_TYPE_END, '>'],
           [lex.TokenType.EOF, ''],
-        ]);
-      });
-
-      it('should report missing end doctype', () => {
-        expect(tokenizeAndHumanizeErrors('<!')).toEqual([
-          [lex.TokenType.DOC_TYPE_START, 'Unexpected character "EOF"', '0:2']
         ]);
       });
     });
@@ -147,12 +155,6 @@ import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../src/parse_u
           [lex.TokenType.RAW_TEXT, 't\ne\rs\r\nt'],
           [lex.TokenType.CDATA_END, ']]>'],
           [lex.TokenType.EOF, ''],
-        ]);
-      });
-
-      it('should report <![ without CDATA[', () => {
-        expect(tokenizeAndHumanizeErrors('<![a')).toEqual([
-          [lex.TokenType.CDATA_START, 'Unexpected character "a"', '0:3']
         ]);
       });
 


### PR DESCRIPTION
Ref: https://www.w3.org/TR/html5/syntax.html#bogus-comment-state

- `<! ... >`
- `<? ... >`