### PR TITLE
feat: add an option to customize tag content type

### DIFF
--- a/packages/angular-html-parser/README.md
+++ b/packages/angular-html-parser/README.md
@@ -31,24 +31,30 @@ const { rootNodes, errors } = ngHtmlParser.parse('<div>hello world</div>');
 declare function parse(input: string, options?: Options): ng.ParseTreeResult;
 
 interface Options {
-  /** 
+  /**
    * any element can self close
    *
    * defaults to false
    */
   canSelfClose?: boolean;
-  /** 
+  /**
    * support [`htm`](https://github.com/developit/htm) component closing tags (`<//>`) 
    *
    * defaults to false
    */
   allowHtmComponentClosingTags?: boolean;
-  /** 
+  /**
    * do not lowercase tag names before querying their tag definitions
    *
    * defaults to false
    */
   isTagNameCaseSensitive?: boolean;
+  /**
+   * customize tag content type
+   *
+   * defaults to the content type defined in the HTML spec
+   */
+  getTagContentType?: (tagName: string) => ng.TagContentType,
 }
 ```
 

--- a/packages/angular-html-parser/src/index.ts
+++ b/packages/angular-html-parser/src/index.ts
@@ -1,4 +1,5 @@
 import { HtmlParser } from "../../compiler/src/ml_parser/html_parser";
+import { TagContentType } from '../../compiler/src/ml_parser/tags';
 
 let parser: HtmlParser | null = null;
 
@@ -9,14 +10,45 @@ const getParser = () => {
   return parser;
 };
 
+export { TagContentType };
+
+export interface ParseOptions {
+  /**
+   * any element can self close
+   *
+   * defaults to false
+   */
+  canSelfClose?: boolean,
+  /**
+   * support [`htm`](https://github.com/developit/htm) component closing tags (`<//>`)
+   *
+   * defaults to false
+   */
+  allowHtmComponentClosingTags?: boolean,
+  /**
+   * do not lowercase tag names before querying their tag definitions
+   *
+   * defaults to false
+   */
+  isTagNameCaseSensitive?: boolean,
+  /**
+   * customize tag content type
+   *
+   * defaults to the content type defined in the HTML spec
+   */
+  getTagContentType?: (tagName: string) => TagContentType,
+}
+
 export function parse(
   input: string,
-  {
+  options: ParseOptions = {}
+) {
+  const {
     canSelfClose = false,
     allowHtmComponentClosingTags = false,
-    isTagNameCaseSensitive = false
-  } = {}
-) {
+    isTagNameCaseSensitive = false,
+    getTagContentType,
+  } = options;
   return getParser().parse(
     input,
     "angular-html-parser",
@@ -24,8 +56,9 @@ export function parse(
       tokenizeExpansionForms: false,
       interpolationConfig: undefined,
       canSelfClose,
-      allowHtmComponentClosingTags
+      allowHtmComponentClosingTags,
     },
-    isTagNameCaseSensitive
+    isTagNameCaseSensitive,
+    getTagContentType,
   );
 }

--- a/packages/compiler/src/ml_parser/html_parser.ts
+++ b/packages/compiler/src/ml_parser/html_parser.ts
@@ -9,13 +9,14 @@
 import {getHtmlTagDefinition} from './html_tags';
 import {TokenizeOptions} from './lexer';
 import {ParseTreeResult, Parser} from './parser';
+import {TagContentType} from './tags';
 
 export {ParseTreeResult, TreeError} from './parser';
 
 export class HtmlParser extends Parser {
   constructor() { super(getHtmlTagDefinition); }
 
-  parse(source: string, url: string, options?: TokenizeOptions, isTagNameCaseSensitive = false): ParseTreeResult {
-    return super.parse(source, url, options, isTagNameCaseSensitive);
+  parse(source: string, url: string, options?: TokenizeOptions, isTagNameCaseSensitive = false, getTagContentType?: (tagName: string) => TagContentType): ParseTreeResult {
+    return super.parse(source, url, options, isTagNameCaseSensitive, getTagContentType);
   }
 }

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -108,9 +108,9 @@ export interface TokenizeOptions {
 }
 
 export function tokenize(
-    source: string, url: string, getTagDefinition: (tagName: string) => TagDefinition,
+    source: string, url: string, getTagContentType: (tagName: string) => TagContentType,
     options: TokenizeOptions = {}): TokenizeResult {
-  return new _Tokenizer(new ParseSourceFile(source, url), getTagDefinition, options).tokenize();
+  return new _Tokenizer(new ParseSourceFile(source, url), getTagContentType, options).tokenize();
 }
 
 const _CR_OR_CRLF_REGEXP = /\r\n?/g;
@@ -145,11 +145,11 @@ class _Tokenizer {
 
   /**
    * @param _file The html source file being tokenized.
-   * @param _getTagDefinition A function that will retrieve a tag definition for a given tag name.
+   * @param _getTagContentType A function that will retrieve a tag content type for a given tag name.
    * @param options Configuration of the tokenization.
    */
   constructor(
-      _file: ParseSourceFile, private _getTagDefinition: (tagName: string) => TagDefinition,
+      _file: ParseSourceFile, private _getTagContentType: (tagName: string) => TagContentType,
       options: TokenizeOptions) {
     this._tokenizeIcu = options.tokenizeExpansionForms || false;
     this._interpolationConfig = options.interpolationConfig || DEFAULT_INTERPOLATION_CONFIG;
@@ -543,7 +543,7 @@ class _Tokenizer {
       return;
     }
 
-    const contentTokenType = this._getTagDefinition(tagName).contentType;
+    const contentTokenType = this._getTagContentType(tagName);
 
     if (contentTokenType === TagContentType.RAW_TEXT) {
       this._consumeRawTextWithTagClose(prefix, tagName, false);


### PR DESCRIPTION
Fixes #11

The tag content type resolution happens in the lexing phase so there is no info for element stack, i.e., something like `getTagContentType(tagName, elementStack)` is not possible under this architecture, which means there is no way to identify if an element is a root element, so we probably need to do two-pass parsing for the Vue SFC, one for the root elements and one for `<template>`s.

cc @sosukesuzuki @fisker @thorn0