### PR TITLE
feat(getTagContentType): add `prefix` and `hasParent` parameters

### DIFF
--- a/packages/angular-html-parser/README.md
+++ b/packages/angular-html-parser/README.md
@@ -54,7 +54,7 @@ interface Options {
    *
    * defaults to the content type defined in the HTML spec
    */
-  getTagContentType?: (tagName: string) => ng.TagContentType,
+  getTagContentType?: (tagName: string, prefix: string, hasParent: boolean) => void | ng.TagContentType,
 }
 ```
 

--- a/packages/angular-html-parser/package.json
+++ b/packages/angular-html-parser/package.json
@@ -16,7 +16,7 @@
     "prepublish": "yarn run build",
     "prebuild": "rm -rf ./lib",
     "build": "tsc -p tsconfig.build.json",
-    "test": "ts-node --transpileOnly --project tsconfig.test.json -r tsconfig-paths/register node_modules/.bin/jasmine ../compiler/test/ml_parser/*_spec.ts",
+    "test": "ts-node --transpileOnly --project tsconfig.test.json -r tsconfig-paths/register node_modules/.bin/jasmine ../compiler/test/ml_parser/*_spec.ts ./test/*_spec.ts",
     "release": "standard-version"
   },
   "dependencies": {

--- a/packages/angular-html-parser/src/index.ts
+++ b/packages/angular-html-parser/src/index.ts
@@ -36,7 +36,11 @@ export interface ParseOptions {
    *
    * defaults to the content type defined in the HTML spec
    */
-  getTagContentType?: (tagName: string) => TagContentType,
+  getTagContentType?: (
+    tagName: string,
+    prefix: string,
+    hasParent: boolean
+  ) => void | TagContentType,
 }
 
 export function parse(

--- a/packages/angular-html-parser/test/index_spec.ts
+++ b/packages/angular-html-parser/test/index_spec.ts
@@ -1,0 +1,41 @@
+import { parse, TagContentType } from "../src/index";
+import { humanizeDom } from "../../compiler/test/ml_parser/ast_spec_utils";
+import * as html from "../../compiler/src/ml_parser/ast";
+
+describe("options", () => {
+  describe("getTagContentType", () => {
+    it("should be able to parse Vue SFC", () => {
+      const input = `
+<template>
+  <MyComponent>
+    <template #content>
+      text
+    </template>
+  </MyComponent>
+</template>
+<custom lang="babel">
+  const foo = "</";
+</custom>
+`.replace(/\n */g, "");
+      const getTagContentType = (
+        tagName: string,
+        prefix: string,
+        hasParent: boolean
+      ) => {
+        if (!hasParent && tagName !== "template") {
+          return TagContentType.RAW_TEXT;
+        }
+      };
+      expect(humanizeDom(parse(input, { getTagContentType }))).toEqual([
+        [html.Element, "template", 0],
+        [html.Element, "MyComponent", 1],
+        [html.Element, "template", 2],
+        [html.Attribute, "#content", ""],
+        [html.Text, "text", 3],
+        [html.Element, "custom", 0],
+        [html.Attribute, "lang", "babel"],
+        [html.Text, 'const foo = "</";', 1]
+      ]);
+    });
+  });
+});

--- a/packages/compiler/src/ml_parser/html_parser.ts
+++ b/packages/compiler/src/ml_parser/html_parser.ts
@@ -16,7 +16,7 @@ export {ParseTreeResult, TreeError} from './parser';
 export class HtmlParser extends Parser {
   constructor() { super(getHtmlTagDefinition); }
 
-  parse(source: string, url: string, options?: TokenizeOptions, isTagNameCaseSensitive = false, getTagContentType?: (tagName: string) => TagContentType): ParseTreeResult {
+  parse(source: string, url: string, options?: TokenizeOptions, isTagNameCaseSensitive = false, getTagContentType?: (tagName: string, prefix: string, hasParent: boolean) => void | TagContentType): ParseTreeResult {
     return super.parse(source, url, options, isTagNameCaseSensitive, getTagContentType);
   }
 }


### PR DESCRIPTION
Context: https://github.com/ikatyang/angular-html-parser/issues/11#issuecomment-620560801

This PR adds two parameters for `getTagContentType` so that Vue SFC could be correctly parsed:

- `prefix`: the namespace
- `hasParent`: determine if it's a root element

The implementation for `hasParent` is a bit hacky, it

- initializes a stack to record tag names,
- push the tag name to the stack once it meets a root open tag or a open tag with the same tag name as the root tag,
- pop the tag name once it meets the corresponding close tag, and
- `hasParent` is considered `true` if the stack is empty at the moment.

The reason why I implemented it this way is that I don't want to duplicate the entire parsing process in the lexer, though there are some drawbacks for the current implementation:

- void tags won't work if they are root elements
- tags with special rules won't work if they are root elements, for example:
  - `<li>` could be closed by a sibling `<li>` but it won't work if it's a root element
  - `<tr>` could be closed by a parent `</tbody>` but it won't work if it's a root element
- `htm` closing tags (`<//>`) won't work if they are root elements or their names are the same as the root element

But I think it should be fine for the Vue SFC parsing since no one would encounter these edge cases in real life IMO.

This PR also contains a test case for Vue SFC parsing.

cc @fisker @thorn0 @sosukesuzuki