### PR TITLE
feat: add `type` field to nodes and use enumerable node type

### DIFF
--- a/packages/angular-html-parser/README.md
+++ b/packages/angular-html-parser/README.md
@@ -67,6 +67,7 @@ interface Options {
 - fix `Comment#sourceSpan`
 - support [bogus comments](https://www.w3.org/TR/html5/syntax.html#bogus-comment-state) (`<!...>`, `<?...>`)
 - support full [named entities](https://html.spec.whatwg.org/multipage/entities.json)
+- add `type` property to nodes
 
 ## Development
 

--- a/packages/angular-html-parser/test/index_spec.ts
+++ b/packages/angular-html-parser/test/index_spec.ts
@@ -50,3 +50,21 @@ describe("options", () => {
     });
   });
 });
+
+describe("AST format", () => {
+  it("should have `type` property", () => {
+    const input = `<!DOCTYPE html> <el attr></el>txt<!--  --><![CDATA[foo]]>`;
+    const ast = parse(input);
+    expect(ast.rootNodes).toEqual([
+      jasmine.objectContaining({ type: "docType" }),
+      jasmine.objectContaining({ type: "text" }),
+      jasmine.objectContaining({
+        type: "element",
+        attrs: [jasmine.objectContaining({ type: "attribute" })],
+      }),
+      jasmine.objectContaining({ type: "text" }),
+      jasmine.objectContaining({ type: "comment" }),
+      jasmine.objectContaining({ type: "cdata" }),
+    ]);
+  });
+});

--- a/packages/compiler/src/ml_parser/ast.ts
+++ b/packages/compiler/src/ml_parser/ast.ts
@@ -10,22 +10,25 @@ import {AstPath} from '../ast_path';
 import {AST as I18nAST} from '../i18n/i18n_ast';
 import {ParseSourceSpan} from '../parse_util';
 
-export interface Node {
+interface BaseNode {
   sourceSpan: ParseSourceSpan;
   visit(visitor: Visitor, context: any): any;
 }
 
-export class Text implements Node {
+export type Node = Attribute|CDATA|Comment|DocType|Element|Text;
+// Expansion|ExpansionCase -- not used
+
+export class Text implements BaseNode {
   constructor(public value: string, public sourceSpan: ParseSourceSpan, public i18n?: I18nAST) {}
   visit(visitor: Visitor, context: any): any { return visitor.visitText(this, context); }
 }
 
-export class CDATA implements Node {
+export class CDATA implements BaseNode {
   constructor(public value: string, public sourceSpan: ParseSourceSpan) {}
   visit(visitor: Visitor, context: any): any { return visitor.visitCdata(this, context); }
 }
 
-export class Expansion implements Node {
+export class Expansion implements BaseNode {
   constructor(
       public switchValue: string, public type: string, public cases: ExpansionCase[],
       public sourceSpan: ParseSourceSpan, public switchValueSourceSpan: ParseSourceSpan,
@@ -33,7 +36,7 @@ export class Expansion implements Node {
   visit(visitor: Visitor, context: any): any { return visitor.visitExpansion(this, context); }
 }
 
-export class ExpansionCase implements Node {
+export class ExpansionCase implements BaseNode {
   constructor(
       public value: string, public expression: Node[], public sourceSpan: ParseSourceSpan,
       public valueSourceSpan: ParseSourceSpan, public expSourceSpan: ParseSourceSpan) {}
@@ -41,14 +44,14 @@ export class ExpansionCase implements Node {
   visit(visitor: Visitor, context: any): any { return visitor.visitExpansionCase(this, context); }
 }
 
-export class Attribute implements Node {
+export class Attribute implements BaseNode {
   constructor(
       public name: string, public value: string, public sourceSpan: ParseSourceSpan,
       public valueSpan: ParseSourceSpan|null = null, public nameSpan: ParseSourceSpan|null = null, public i18n: I18nAST|null = null) {}
   visit(visitor: Visitor, context: any): any { return visitor.visitAttribute(this, context); }
 }
 
-export class Element implements Node {
+export class Element implements BaseNode {
   constructor(
       public name: string, public attrs: Attribute[], public children: Node[],
       public sourceSpan: ParseSourceSpan, public startSourceSpan: ParseSourceSpan|null = null,
@@ -56,12 +59,12 @@ export class Element implements Node {
   visit(visitor: Visitor, context: any): any { return visitor.visitElement(this, context); }
 }
 
-export class Comment implements Node {
+export class Comment implements BaseNode {
   constructor(public value: string|null, public sourceSpan: ParseSourceSpan) {}
   visit(visitor: Visitor, context: any): any { return visitor.visitComment(this, context); }
 }
 
-export class DocType implements Node {
+export class DocType implements BaseNode {
   constructor(public value: string|null, public sourceSpan: ParseSourceSpan) {}
   visit(visitor: Visitor, context: any): any { return visitor.visitDocType(this, context); }
 }

--- a/packages/compiler/src/ml_parser/ast.ts
+++ b/packages/compiler/src/ml_parser/ast.ts
@@ -21,11 +21,13 @@ export type Node = Attribute|CDATA|Comment|DocType|Element|Text;
 export class Text implements BaseNode {
   constructor(public value: string, public sourceSpan: ParseSourceSpan, public i18n?: I18nAST) {}
   visit(visitor: Visitor, context: any): any { return visitor.visitText(this, context); }
+  readonly type = 'text';
 }
 
 export class CDATA implements BaseNode {
   constructor(public value: string, public sourceSpan: ParseSourceSpan) {}
   visit(visitor: Visitor, context: any): any { return visitor.visitCdata(this, context); }
+  readonly type = 'cdata';
 }
 
 export class Expansion implements BaseNode {
@@ -49,6 +51,7 @@ export class Attribute implements BaseNode {
       public name: string, public value: string, public sourceSpan: ParseSourceSpan,
       public valueSpan: ParseSourceSpan|null = null, public nameSpan: ParseSourceSpan|null = null, public i18n: I18nAST|null = null) {}
   visit(visitor: Visitor, context: any): any { return visitor.visitAttribute(this, context); }
+  readonly type = 'attribute';
 }
 
 export class Element implements BaseNode {
@@ -57,16 +60,19 @@ export class Element implements BaseNode {
       public sourceSpan: ParseSourceSpan, public startSourceSpan: ParseSourceSpan|null = null,
       public endSourceSpan: ParseSourceSpan|null = null, public nameSpan: ParseSourceSpan|null = null, public i18n: I18nAST|null = null) {}
   visit(visitor: Visitor, context: any): any { return visitor.visitElement(this, context); }
+  readonly type = 'element';
 }
 
 export class Comment implements BaseNode {
   constructor(public value: string|null, public sourceSpan: ParseSourceSpan) {}
   visit(visitor: Visitor, context: any): any { return visitor.visitComment(this, context); }
+  readonly type = 'comment';
 }
 
 export class DocType implements BaseNode {
   constructor(public value: string|null, public sourceSpan: ParseSourceSpan) {}
   visit(visitor: Visitor, context: any): any { return visitor.visitDocType(this, context); }
+  readonly type = 'docType';
 }
 
 export interface Visitor {
@@ -77,7 +83,7 @@ export interface Visitor {
   visitElement(element: Element, context: any): any;
   visitAttribute(attribute: Attribute, context: any): any;
   visitText(text: Text, context: any): any;
-  visitCdata(text: Text, context: any): any;
+  visitCdata(text: CDATA, context: any): any;
   visitComment(comment: Comment, context: any): any;
   visitDocType(docType: DocType, context: any): any;
   visitExpansion(expansion: Expansion, context: any): any;
@@ -116,6 +122,8 @@ export class RecursiveVisitor implements Visitor {
   visitDocType(ast: DocType, context: any): any {}
 
   visitExpansion(ast: Expansion, context: any): any {
+    // `ExpansionCase` is excluded from `Node` in angular-html-parser.
+    // @ts-ignore -- Using ts-ignore here to minimize efforts on merging upstream changes.
     return this.visitChildren(context, visit => { visit(ast.cases); });
   }
 

--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -162,7 +162,8 @@ class _TreeBuilder {
       return;
     }
     const sourceSpan = new ParseSourceSpan(token.sourceSpan.start, this._peek.sourceSpan.end);
-    // @ts-ignore
+    // `Expansion` is excluded from `Node` in angular-html-parser as it doesn't generate such nodes.
+    // @ts-ignore -- Using ts-ignore here to minimize efforts on merging upstream changes.
     this._addToParent(new html.Expansion(
         switchValue.parts[0], type.parts[0], cases, sourceSpan, switchValue.sourceSpan));
 

--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -162,6 +162,7 @@ class _TreeBuilder {
       return;
     }
     const sourceSpan = new ParseSourceSpan(token.sourceSpan.start, this._peek.sourceSpan.end);
+    // @ts-ignore
     this._addToParent(new html.Expansion(
         switchValue.parts[0], type.parts[0], cases, sourceSpan, switchValue.sourceSpan));
 


### PR DESCRIPTION
We're gradually adding type checking to Prettier's codebase. This change would make it simpler.

Also, how about adding the `type` field here, not in Prettier, to make this union type tagged out of the box? 